### PR TITLE
Source urls for metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.1.2: (2015-11-17)
+
+* Food critic fixes
+
+## 0.1.1: (2015-08-20)
+
+* Initial public version of plex cookbook.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 plex Cookbook
 =============
-Installs the latest version of Plex
+Installs the latest version of Plex by parsing plex.tv/downloads and grabbing latest .rpm or .deb package.
 
 Requirements
 ------------

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,9 @@ maintainer       'Henry Muru Paenga'
 maintainer_email 'meringu@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures plex'
+source_url       'https://github.com/meringu/plex'
+issues_url       'https://github.com/meringu/plex/issues'
+
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.2'
 supports         'ubuntu', '>= 10.04'


### PR DESCRIPTION
Found in supermarket but had do to some guessing to get over to the source code.  

This will allow supermarket to link directly to the github code and issue tracker.

Also figured a CHANGELOG.md will be helpful going forward.
