### PR TITLE
Use API to get download links

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,8 +6,8 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-7.1
-  - name: fedora-19
+  - name: centos-7.2
+  - name: fedora-22
   - name: ubuntu-14.04
 
 suites:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,5 @@
+# Leave as nil for public channel; plexpass for plex pass channel
+default['plex']['channel'] = nil
+
+# Must be set if channel is set to plexpass
+default['plex']['token'] = nil

--- a/libraries/plex_release_api.rb
+++ b/libraries/plex_release_api.rb
@@ -1,0 +1,97 @@
+require 'openssl'
+require 'net/http'
+require 'net/https'
+require 'json'
+
+module Plex
+  module ReleaseApi
+    DEFAULT_API_URL = 'https://plex.tv'.freeze
+
+    class Client
+      def initialize(opts = {})
+        @api_url = URI(opts[:api_url] || DEFAULT_API_URL)
+        @channel = opts[:channel]
+        @plex_token = opts[:plex_token]
+        validate_opts!
+      end
+
+      def pms_releases
+        releases(1)
+      end
+
+      def pht_releases
+        releases(2)
+      end
+
+      def pmp_releases
+        releases(3)
+      end
+
+      def releases(product)
+        params = {}
+        params['channel'] = @channel if @channel
+        res = api_get("/api/downloads/#{product}.json", params)
+        process_releases(res)
+      end
+
+      private
+
+      def api_get(path, params = {})
+        uri = URI.join(@api_url, path)
+        uri.query = URI.encode_www_form(params)
+        req = Net::HTTP::Get.new(uri)
+        req['X-Plex-Token'] = @plex_token if @plex_token
+        http = Net::HTTP.new(@api_url.host, @api_url.port)
+        http.use_ssl = true if @api_url.scheme == 'https'
+        http.request(req)
+      end
+
+      def process_releases(res)
+        rels = {}
+        hsh = JSON.parse(res.body)
+        hsh.each do |hardware, oses|
+          next unless hardware == 'computer'
+          oses.each do |os, meta|
+            meta['releases'].each do |rel|
+              distro =  case os
+                        when 'Windows'
+                          'windows'
+                        when 'Linux'
+                          case rel['label']
+                          when /centos/i
+                            'rhel'
+                          when /fedora/i
+                            'fedora'
+                          when /ubuntu/i
+                            'debian'
+                          else
+                            rel['distro']
+                          end
+                        when 'FreeBSD'
+                          'freebsd'
+                        when 'Mac'
+                          'mac_os_x'
+                        else
+                          next
+                        end
+              rels[distro] ||= {}
+              arch = rel['build'].split('-').last
+              rels[distro][arch] = rel['url']
+            end
+          end
+        end
+        rels
+      end
+
+      def validate_opts!
+        unless [nil, 'plexpass'].include?(@channel)
+          fail ArgumentError, "Invalid channel '#{@channel}'"
+        end
+
+        if @channel == 'plexpass' && @plex_token.to_s.empty?
+          fail ArgumentError, "'plex_token' must be set when using channel 'plexpass'"
+        end
+      end
+    end
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,30 +7,4 @@
 # All rights reserved - Do Not Redistribute
 #
 
-distro = ''
-if node['platform_family'].include?('rhel')
-  distro = 'CentOS'
-elsif node['platform_family'].include?('fedora')
-  distro = 'Fedora'
-elsif node['platform_family'].include?('debian')
-  distro = 'Ubuntu'
-else
-  raise
-end
-bits = node['kernel']['machine'] =~ /64/ ? 64 : 32
-
-lines = open('https://plex.tv/downloads').read
-a = /http.+#{distro}.+#{bits}-bit<\/a>/.match(lines)
-href = a.to_s.gsub /<.+href="|" class.+/, ''
-file = "#{Chef::Config[:file_cache_path]}/#{href.gsub /.+\//, ''}"
-
-remote_file file do
-  source href
-  action :create
-end
-
-if node['platform_family'].include?('rhel') || node['platform_family'].include?('fedora')
-  rpm_package file
-elsif node['platform_family'].include?('debian')
-  dpkg_package file
-end
+include_recipe 'plex::pms'

--- a/recipes/pms.rb
+++ b/recipes/pms.rb
@@ -1,0 +1,17 @@
+arch = node['kernel']['machine']
+platform_family = node['platform_family']
+installer_file = "#{Chef::Config[:file_cache_path]}/plex_installer"
+client = Plex::ReleaseApi::Client.new(channel: node['plex']['channel'],
+                                      plex_token: node['plex']['token'])
+
+remote_file installer_file do
+  source client.pms_releases[platform_family][arch]
+  action :create
+end
+
+case node['platform_family']
+when 'debian'
+  dpkg_package installer_file
+when 'fedora', 'rhel'
+  rpm_package installer_file
+end


### PR DESCRIPTION
Plex recently redesigned their main site and as a result scraping the HTML of the downloads page is no longer effective.

This PR changes the cookbook to take advantage of the API that Plex have created to populate the values on their new downloads page. 
