### PR TITLE
Modification to media_server.rb provider

### DIFF
--- a/providers/media_server.rb
+++ b/providers/media_server.rb
@@ -31,17 +31,16 @@ action :install do
     action :create
   end
 
-  case node['platform_family']
-  when 'debian'
-    package 'plexmediaserver' do
-      action :upgrade
-      source installer_file
-      provider Chef::Provider::Package::Dpkg
-  end
-  when 'fedora', 'rhel'
-    rpm_package installer_file
-  else
-    Chef::Application.fatal!("Unsuppoerted platform_family #{node['platform_family']}")
+  package installer_file do
+    action :upgrade
+    provider case node['platform_family']
+    when 'debian'
+      Chef::Provider::Package::Dpkg
+    when 'fedora', 'rhel'
+      Chef::Provider::Package::Rpm
+    else
+      raise "Unsupported platform_family #{node['platform_family']}"
+    end
   end
 end
 

--- a/providers/media_server.rb
+++ b/providers/media_server.rb
@@ -33,7 +33,11 @@ action :install do
 
   case node['platform_family']
   when 'debian'
-    dpkg_package installer_file
+    package 'plexmediaserver' do
+      action :upgrade
+      source installer_file
+      provider Chef::Provider::Package::Dpkg
+  end
   when 'fedora', 'rhel'
     rpm_package installer_file
   else

--- a/spec/unit/providers/media_server_spec.rb
+++ b/spec/unit/providers/media_server_spec.rb
@@ -14,6 +14,16 @@ describe 'plex_media_server' do
     end
   end
 
+  let(:package_file) do
+    if platform == 'ubuntu'
+      'plexmediaserver.deb'
+    else
+      'plexmediaserver.rpm'
+    end
+  end
+
+  let(:package_cache_path) { File.join(file_cache_path, package_file) }
+
   let(:plex_release_api_client) { double('Plex::ReleaseApi::Client') }
 
   let(:chef_run) do
@@ -47,13 +57,8 @@ describe 'plex_media_server' do
       let(:action) { 'install' }
 
       it 'should install plex media server' do
-        if platform == 'ubuntu'
-          expect(chef_run).to create_remote_file('/var/chef/cahce/plexmediaserver.deb').with(source: download_link)
-          expect(chef_run).to install_dpkg_package('/var/chef/cahce/plexmediaserver.deb')
-        else
-          expect(chef_run).to create_remote_file('/var/chef/cahce/plexmediaserver.rpm').with(source: download_link)
-          expect(chef_run).to install_rpm_package('/var/chef/cahce/plexmediaserver.rpm')
-        end
+        expect(chef_run).to create_remote_file(package_cache_path).with(source: download_link)
+        expect(chef_run).to upgrade_package(package_cache_path)
       end
     end
 


### PR DESCRIPTION
The default 'install' action of the dpkg_package resource won't overwrite/upgrade a package that's already installed, regardless of the version difference. Using the package resource and calling the dpkg provider with the upgrade action gets around that limitation.