### PR TITLE
New release url

### DIFF
--- a/libraries/plex_release_api.rb
+++ b/libraries/plex_release_api.rb
@@ -16,7 +16,7 @@ module Plex
       end
 
       def pms_releases
-        releases(1)
+        releases(5)
       end
 
       def pht_releases

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ source_url       'https://github.com/meringu/plex'
 issues_url       'https://github.com/meringu/plex/issues'
 
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.3'
+version          '0.2.4'
 supports         'ubuntu'
 supports         'fedora'
 supports         'centos'


### PR DESCRIPTION
Seems like that the release URL for pms changed from `1.json` to `5.json` and updating pms break since march 12. This updates the url and fixes it.

fixes #7 